### PR TITLE
support generate and execute by json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ go tool compile -I $GOPATH/pkg/`go env GOOS`_`go env GOARCH`/ $GOPATH/src/github
 go tool compile -I $GOPATH/pkg/`go env GOOS`_`go env GOARCH`/ -o test.o test1.go test2.go
 ./loader -o test.o -run main.main
 
+#execute by json file
+go build github.com/pkujhd/goloader/cmd
+./cmd -p github.com/pkujhd/goloader/examples/inter -j test.json
+go build github.com/pkujhd/goloader/examples/loaderByJson
+./loaderByJson -j test.json
 ```
 
 ## Warning

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type ObjInfo struct {
+	PackageName string
+	ObjFilePath string
+	ObjFileHash string
+}
+
+type Builder struct {
+	ObjInfos    []ObjInfo
+	ExecuteFunc []string
+	files       []string
+	packageName string
+	packagePath string
+}
+
+func (b *Builder) AddExecuteFunc(packageName string, funcName string) {
+	b.ExecuteFunc = append(b.ExecuteFunc, packageName+"."+funcName)
+}
+
+func GetEnv() {
+	fmt.Println(runtime.GOROOT())
+	fmt.Println(os.Getenv("GOPATH"))
+}
+
+func CleanCache() error {
+	return exec.Command("go", "clean", "--cache").Run()
+}
+
+func BuildPackage(name string) (output string, workDir string, err error) {
+	cmd := exec.Command("go", "build", "-a", "-x", "-work", name)
+	outBuf, err := cmd.CombinedOutput()
+	output = string(outBuf)
+	lines := strings.Split(output, "\n")
+	if len(lines) <= 0 || !strings.Contains(lines[0], "WORK=") {
+		fmt.Println("err")
+	}
+	workDir = filepath.Join(strings.TrimPrefix(lines[0], "WORK="), "b001")
+	return output, workDir, err
+}
+
+func RenameAndCopyObjFile(packageName string, oldPath string, prefix string) string {
+	newName := strings.ReplaceAll(packageName, ".", "_")
+	newName = strings.ReplaceAll(newName, "/", "_")
+	newName = strings.ReplaceAll(newName, "\\", "_")
+	newName = "goloader_" + newName + ".a"
+	if prefix != "" {
+		newName = filepath.Join(prefix, newName)
+	}
+	err := os.Rename(oldPath, newName)
+	if err != nil {
+		fmt.Println("Rename Failed", err)
+	}
+	newName, _ = filepath.Abs(newName)
+	return newName
+}
+
+var clean = true
+
+func (b *Builder) BuildPackageObjs() {
+	CleanCache()
+	_, workDir, _ := BuildPackage(b.packageName)
+	file, err := os.Open(filepath.Join(workDir, "importcfg"))
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+	packageFiles, err := ioutil.ReadAll(file)
+	if err != nil {
+		return
+	}
+	b.ObjInfos = append(b.ObjInfos, ObjInfo{PackageName: b.packageName, ObjFilePath: RenameAndCopyObjFile(b.packageName, workDir+"/_pkg_.a", "")})
+	for _, packagefile := range strings.Split(string(packageFiles), "\n") {
+		if strings.HasPrefix(packagefile, "packagefile ") {
+			tmp := strings.Split(strings.TrimPrefix(packagefile, "packagefile "), "=")
+			b.ObjInfos = append(b.ObjInfos, ObjInfo{PackageName: tmp[0], ObjFilePath: RenameAndCopyObjFile(tmp[0], tmp[1], "")})
+		}
+	}
+	if clean {
+		os.RemoveAll(workDir)
+	}
+}
+
+func (b *Builder) SearchExecute() {
+	for _, file := range b.files {
+		srcData, err := ioutil.ReadFile(filepath.Join(b.packagePath, file))
+		if err != nil {
+			fmt.Println(err)
+		}
+		fset := token.NewFileSet()
+		fparser, err := parser.ParseFile(fset, "", srcData, parser.ParseComments)
+		if err != nil {
+			fmt.Println(err)
+		}
+		// TODO:support dependency.
+		for _, decl := range fparser.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Doc != nil && fn.Doc.List != nil {
+				for _, doc := range fn.Doc.List {
+					if doc.Text == "//go:execute" {
+						b.AddExecuteFunc(fparser.Name.String(), fn.Name.String())
+					}
+				}
+			}
+		}
+	}
+
+}
+
+func (b *Builder) MarshalData() {
+	mar, _ := json.MarshalIndent(b, "", "\t")
+	fmt.Println(string(mar))
+}
+
+func (b *Builder) WriteToFile(path string) {
+	f, err := os.Create(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	mar, _ := json.MarshalIndent(b, "", "\t")
+	f.Write(mar)
+}
+
+func InitBuild(packageName string) *Builder {
+	b := &Builder{packageName: packageName}
+
+	// Get dir path.
+	cmd := exec.Command("go", "list", "-f", "{{.Dir}}", packageName)
+	outBuf, _ := cmd.CombinedOutput()
+	b.packagePath = strings.Trim(string(outBuf), "\n")
+
+	// Get all files.
+	// TODO: support build tags.
+	cmd = exec.Command("go", "list", "-f", "{{.GoFiles}}", packageName)
+	outBuf, _ = cmd.CombinedOutput()
+	b.files = strings.Split(strings.Trim(string(outBuf), "[]\n"), " ")
+	return b
+}
+
+func main() {
+	var packageName = flag.String("p", "", "package name")
+	var jsonFilePath = flag.String("j", "./goloader.json", "json file path")
+	flag.Parse()
+
+	builder := InitBuild(*packageName)
+	builder.BuildPackageObjs()
+	builder.SearchExecute()
+	builder.WriteToFile(*jsonFilePath)
+}

--- a/examples/inter/inter.go
+++ b/examples/inter/inter.go
@@ -23,6 +23,8 @@ func bcontextPrint(i basecontext.IBaseContext) {
 	i.PrintName()
 	fmt.Println("bcontextPrint", i.GetName())
 }
+
+//go:execute
 func main() {
 	var scontext basecontext.TSContext
 	var bcontext basecontext.TBaseContext

--- a/examples/loaderByJson/main.go
+++ b/examples/loaderByJson/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"unsafe"
+
+	"github.com/pkujhd/goloader"
+)
+
+type ObjInfo struct {
+	PackageName string
+	ObjFilePath string
+	ObjFileHash string
+}
+
+type Builder struct {
+	ObjInfos    []ObjInfo
+	ExecuteFunc []string
+	packageName string
+	packagePath string
+}
+
+type arrayFlags struct {
+	File    []string
+	PkgPath []string
+}
+
+func (i *arrayFlags) String() string {
+	return "my string representation"
+}
+
+func (i *arrayFlags) Set(value string) error {
+	s := strings.Split(value, ":")
+	i.File = append(i.File, s[0])
+	var path string
+	if len(s) > 1 {
+		path = s[1]
+	}
+	i.PkgPath = append(i.PkgPath, path)
+	return nil
+}
+
+func main() {
+	var jsonFilePath = flag.String("j", "./goloader.json", "json file path")
+	flag.Parse()
+	file, err := os.Open(*jsonFilePath)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer file.Close()
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	var files arrayFlags
+	b := &Builder{}
+	json.Unmarshal(data, b)
+	for _, info := range b.ObjInfos {
+		// FIXME: Optimize this conditional judgment.
+		if info.PackageName != "fmt" && info.PackageName != "runtime" {
+			files.Set(info.ObjFilePath + ":" + info.PackageName)
+		}
+	}
+
+	if len(files.File) == 0 {
+		flag.PrintDefaults()
+		return
+	}
+
+	symPtr := make(map[string]uintptr)
+	err = goloader.RegSymbol(symPtr)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	// most of time you don't need to register function, but if loader complain about it, you have to.
+	w := sync.WaitGroup{}
+	goloader.RegTypes(symPtr, http.ListenAndServe, http.Dir("/"),
+		http.Handler(http.FileServer(http.Dir("/"))), http.FileServer, http.HandleFunc,
+		&http.Request{}, &http.Server{})
+	goloader.RegTypes(symPtr, runtime.LockOSThread, &w, w.Wait)
+	goloader.RegTypes(symPtr, fmt.Sprint)
+
+	linker, err := goloader.ReadObjs(files.File, files.PkgPath)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	var mmapByte []byte
+	codeModule, err := goloader.Load(linker, symPtr)
+	if err != nil {
+		fmt.Println("Load error:", err)
+		return
+	}
+
+	for _, fn := range b.ExecuteFunc {
+		runFuncPtr := codeModule.Syms[fn]
+		if runFuncPtr == 0 {
+			fmt.Println("Load error! not find function:", fn)
+			return
+		}
+		funcPtrContainer := (uintptr)(unsafe.Pointer(&runFuncPtr))
+		runFunc := *(*func())(unsafe.Pointer(&funcPtrContainer))
+		runFunc()
+	}
+
+	os.Stdout.Sync()
+	codeModule.Unload()
+
+	// a strict test, try to make mmap random
+	if mmapByte == nil {
+		mmapByte, err = goloader.Mmap(1024)
+		if err != nil {
+			fmt.Println(err)
+		}
+		b := make([]byte, 1024)
+		copy(mmapByte, b) // reset all bytes
+	} else {
+		goloader.Munmap(mmapByte)
+		mmapByte = nil
+	}
+}


### PR DESCRIPTION
对于依赖多package的场景，希望可以达到自动化分析需要的obj文件（将原二进制作为输入进行静态检查应该可以分析到，当前PR暂未实现该功能 ）  
在生成obj时，将所需信息放置到json文件中，在调用loader时仅需要输入json文件位置即可。  
添加 `//go:execute` 注解，加载后会自动执行被标记的函数，后续还可以支持依赖信息，进行排序来保证执行顺序。  